### PR TITLE
fix: save package with correct unit

### DIFF
--- a/routes/ecom/modules/calculate.js
+++ b/routes/ecom/modules/calculate.js
@@ -191,7 +191,8 @@ module.exports = appSdk => {
                 }
                 if (servicePkg.weight) {
                   shippingLine.package.weight = {
-                    value: parseFloat(servicePkg.weight)
+                    value: parseFloat(servicePkg.weight),
+                    unit: 'kg'
                   }
                 }
               }


### PR DESCRIPTION
Default API E-Com Plus weight unit is 'g' and Melhor envio is 'kg'. So the package weight unit was incorrect.